### PR TITLE
delete works

### DIFF
--- a/backend/prisma/migrations/20241025182006_deleting_likes/migration.sql
+++ b/backend/prisma/migrations/20241025182006_deleting_likes/migration.sql
@@ -1,0 +1,5 @@
+-- DropForeignKey
+ALTER TABLE "Like" DROP CONSTRAINT "Like_artWorkId_fkey";
+
+-- AddForeignKey
+ALTER TABLE "Like" ADD CONSTRAINT "Like_artWorkId_fkey" FOREIGN KEY ("artWorkId") REFERENCES "ArtWork"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/migrations/20241025182826_updated_art_work/migration.sql
+++ b/backend/prisma/migrations/20241025182826_updated_art_work/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "ArtWork" ADD COLUMN     "isAuthor" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "userAvatar" TEXT,
+ADD COLUMN     "userName" TEXT;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -30,6 +30,9 @@ model User {
 model ArtWork {
   id            String   @id @default(uuid())
   configuration Json
+  userAvatar    String?
+  userName      String?
+  isAuthor      Boolean  @default(false)
   createdAt     DateTime @default(now())
   updatedAt     DateTime @updatedAt
 
@@ -45,7 +48,7 @@ model Like {
 
   user      User    @relation(fields: [userId], references: [id])
   userId    String
-  artWorks  ArtWork @relation(fields: [artWorkId], references: [id])
+  artWorks  ArtWork @relation(fields: [artWorkId], references: [id], onDelete: Cascade)
   artWorkId String
 
   @@unique([userId, artWorkId])

--- a/frontend/src/components/art-components/FeedGrid.tsx
+++ b/frontend/src/components/art-components/FeedGrid.tsx
@@ -37,14 +37,18 @@ const FeedGrid: React.FC<FeedGridProps> = ({
 
     // Handle publishing new art
     const handlePublishArt = (newArt: ArtType) => {
-        const newFeedItem: FeedItem = {
-            ...newArt,
-            userName: userName,
-            isAuthor: true
-        };
-        setFeedItems(prevItems => [newFeedItem, ...prevItems]);
-        setEditingArt(null);
-        toast.success('Art published successfully!');
+        try {
+            const newFeedItem: FeedItem = {
+                ...newArt,
+                userName: userName,
+                isAuthor: true
+            };
+            setFeedItems(prevItems => [newFeedItem, ...prevItems]);
+            setEditingArt(null);
+            toast.success('Art published successfully!');
+        } catch (error) {
+            toast.error('Failed to publish art. Please try again.');
+        }
     };
 
     // Handle generating new random art
@@ -55,8 +59,12 @@ const FeedGrid: React.FC<FeedGridProps> = ({
 
     // Handle deleting art
     const handleDelete = (artId: string) => {
-        setFeedItems(prevItems => prevItems.filter(item => item.id !== artId));
-        toast.success('Art deleted successfully!');
+        try {
+            setFeedItems(prevItems => prevItems.filter(item => item.id !== artId));
+            toast.success('Art deleted successfully!');
+        } catch (error) {
+            toast.error('Failed to delete art. Please try again.');
+        }
     };
 
     // Handle editing art
@@ -64,8 +72,12 @@ const FeedGrid: React.FC<FeedGridProps> = ({
         setFeedItems(prevItems => prevItems.map(item =>
             item.id === updatedArt.id ? { ...item, ...updatedArt } : item
         ));
-        if (onEditArt) onEditArt(updatedArt);
-        toast.success('Art updated successfully!');
+        try {
+            if (onEditArt) onEditArt(updatedArt);
+            toast.success('Art updated successfully!');
+        } catch (error) {
+            toast.error('Failed to update art. Please try again.');
+        }
     };
 
     return (

--- a/frontend/src/components/art-components/FeedPost.tsx
+++ b/frontend/src/components/art-components/FeedPost.tsx
@@ -5,6 +5,7 @@ import ArtEditor from './ArtEditor';
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Heart, Edit, Trash2 } from 'lucide-react';
+//import { updateLike } from '../../services/api';
 import {
     AlertDialog,
     AlertDialogAction,
@@ -17,6 +18,7 @@ import {
     AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 import { toast } from 'sonner';
+
 
 interface FeedPostProps {
     art: ArtType & { likeCount?: number };
@@ -37,7 +39,6 @@ const FeedPost: React.FC<FeedPostProps> = ({
     userAvatar,
     userName,
     isAuthor,
-    // onLike,
     onEdit,
     onDelete,
     displayAsGrid = false,
@@ -56,12 +57,8 @@ const FeedPost: React.FC<FeedPostProps> = ({
         const newIsLiked = !isLiked;
         setIsLiked(newIsLiked);
         setLikesCount(prevCount => newIsLiked ? prevCount + 1 : prevCount - 1);
-        // onLike(newIsLiked);
-        if (newIsLiked) {
-            toast.success('Liked!');
-        } else {
-            toast.success('Unliked!');
-        }
+        updateLike(art.id, newIsLiked);
+        toast.success(newIsLiked ? 'Liked!' : 'Unliked!');
     };
 
     const handlePublish = (updatedArt: ArtType) => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> This pull request updates the backend and frontend to handle artwork likes with cascading deletes and improves art publishing and deletion functionalities.
> 
>   - **Backend**:
>     - In `migration.sql`, updated `Like` table to use `ON DELETE CASCADE` for `artWorkId` foreign key.
>     - In `schema.prisma`, added `userAvatar`, `userName`, and `isAuthor` fields to `ArtWork` model.
>     - In `server.ts`, added `/api/art-feed/:id/like` endpoint to handle like/unlike actions.
>   - **Frontend**:
>     - In `Feed.tsx`, `FeedGrid.tsx`, and `FeedPost.tsx`, added logic to handle like/unlike actions and improved error handling for publishing and deleting art.
>     - Updated `FeedPost.tsx` to display like count and handle like button interactions.
>     - Enhanced `Feed.tsx` and `FeedGrid.tsx` to manage state changes when art is published or deleted.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=fractal-bootcamp%2Ffaisal-socialArt&utm_source=github&utm_medium=referral)<sup> for 24fdc3144acb56f8218cb2d02f527696dcf8dcfc. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->